### PR TITLE
Hide blog author avatars

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -66,3 +66,13 @@
 .footer__links {
   text-align: center;
 }
+
+/* Blog author avatars are hidden intentionally to avoid relying on external
+   profile images across a large Apache contributor set. */
+.blog-wrapper .avatar__photo-link {
+  display: none;
+}
+
+.blog-wrapper .avatar__intro {
+  margin-left: 0;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -67,8 +67,9 @@
   text-align: center;
 }
 
-/* Blog author avatars are hidden intentionally to avoid relying on external
-   profile images across a large Apache contributor set. */
+/* Blog author avatars are hidden intentionally because the Apache-hosted site
+   CSP does not allow loading external images from avatars.githubusercontent.com,
+   and relying on remote profile images is brittle across a large contributor set. */
 .blog-wrapper .avatar__photo-link {
   display: none;
 }


### PR DESCRIPTION
The Apache-hosted site’s Content-Security-Policy blocks external avatar images from `avatars.githubusercontent.com`, so we hide the photo element instead of relying on remote profile images.